### PR TITLE
fix isOpen state change when isOpen prop stayed unchanged

### DIFF
--- a/lib/menuFactory.js
+++ b/lib/menuFactory.js
@@ -213,7 +213,7 @@ exports['default'] = function (styles) {
 
     componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
       // Allow open state to be controlled by props.
-      if (nextProps.isOpen !== this.state.isOpen) {
+      if (nextProps.isOpen !== this.props.isOpen && nextProps.isOpen !== this.state.isOpen) {
         this.toggleMenu();
       }
     },

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -186,7 +186,7 @@ export default (styles) => {
 
     componentWillReceiveProps(nextProps) {
       // Allow open state to be controlled by props.
-      if (nextProps.isOpen !== this.state.isOpen) {
+      if (nextProps.isOpen !== this.props.isOpen && nextProps.isOpen !== this.state.isOpen) {
         this.toggleMenu();
       }
     },

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -413,5 +413,30 @@ describe('menuFactory', () => {
       ReactDOM.render(<Menu isOpen />, container);
       expect(component.state.isOpen).to.be.true;
     });
+
+    it('will not change when isOpen prop was not changed', () => {
+      let container = document.createElement('div');
+      let ParentComponent = React.createClass({
+        getInitialState() {
+          return { collapsed: true };
+        },
+        changeProps() {
+          this.setState({
+            collapsed: !this.state.collapsed
+          });
+        },
+        render() {
+          return (
+            <Menu ref="menu" {...this.state} />
+          );
+        }
+      });
+
+      component = ReactDOM.render(<ParentComponent />, container);
+      const menu = component.refs.menu;
+      menu.setState({isOpen: true});
+      component.changeProps();
+      expect(menu.state.isOpen).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
When `<Menu />` component is used in render method of parent component that uses internal state to determine what should be rendered inside `<Menu />`, opened `<Menu />` component gets closed after each state change of its parent component.

This PR fixes it. Also includes test that will fail when change in source will be reverted back.

And thanks for this component btw :)