### PR TITLE
Allow falsy isOpenVal value to be used as isOpen value

### DIFF
--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -25,13 +25,11 @@ export default (styles) => {
     },
 
     toggleMenu(isOpenVal) {
-      // Disregard arg if not a boolean.
-      isOpenVal = typeof isOpenVal === 'boolean' ? isOpenVal : undefined;
-
       // Order important: handle wrappers before setting sidebar state.
       this.applyWrapperStyles();
 
-      const newState = { isOpen: isOpenVal ? isOpenVal : !this.state.isOpen };
+      // Disregard isOpenVal if not a boolean.
+      const newState = { isOpen: typeof isOpenVal === 'boolean' ? isOpenVal : !this.state.isOpen };
       this.setState(newState, this.props.onStateChange.bind(null, newState));
     },
 


### PR DESCRIPTION
Hi there,

In our project we use Redux, so we control visibility using the `isOpen` prop; not just during initial mount but when the user opens or closes the Menu using a custom button (which updates our Redux store, and propagates new props down to the `<Menu>` component):

```javascript
<Menu isOpen={this.props.isOpen}  ...
```

With the latest version `1.5.4` we found that our menu was open by default on page load, even though our initial value for `this.props.isOpen` is false. I think the problem is this line:

```javascript
isOpen: isOpenVal ? isOpenVal : !this.state.isOpen
```

If `isOpenVal` is a boolean but is `false`, then this would incorrectly ignore it and use `!this.state.isOpen`.