### PR TITLE
menu factory

### DIFF
--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -39,7 +39,7 @@ export default (styles) => {
       //adtional actions when menu toggle, sync with external control for example
       if(this.props.additionalToggleMenuActions)
       {
-        this.props.additionalToggleMenuActions(newSate);
+        this.props.additionalToggleMenuActions(newState);
       }
     },
 

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -12,6 +12,7 @@ export default (styles) => {
   return ConfiguredRadium(React.createClass({
 
     propTypes: {
+      additionalToggleMenuActions: React.PropTypes.func,
       customBurgerIcon: React.PropTypes.element,
       customCrossIcon: React.PropTypes.element,
       externalControl: React.PropTypes.bool,
@@ -34,6 +35,12 @@ export default (styles) => {
       // Disregard isOpenVal if not a boolean.
       const newState = { isOpen: typeof isOpenVal === 'boolean' ? isOpenVal : !this.state.isOpen };
       this.setState(newState, this.props.onStateChange.bind(null, newState));
+
+      //adtional actions when menu toggle, sync with external control for example
+      if(this.props.additionalToggleMenuActions)
+      {
+        this.props.additionalToggleMenuActions(newSate);
+      }
     },
 
     // Applies component-specific styles to external wrapper elements.

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -14,8 +14,10 @@ export default (styles) => {
     propTypes: {
       customBurgerIcon: React.PropTypes.element,
       customCrossIcon: React.PropTypes.element,
+      externalControl: React.PropTypes.bool,
       id: React.PropTypes.string,
       isOpen: React.PropTypes.bool,
+      noCrossButton: React.PropTypes.bool,
       noOverlay: React.PropTypes.bool,
       onStateChange: React.PropTypes.func,
       outerContainerId: React.PropTypes.string,
@@ -194,33 +196,43 @@ export default (styles) => {
     },
 
     render() {
-      let items, svg, overlay;
+      debugger;
+      const crossButton = (!this.props.noCrossButton) ? (
+          <div style={ this.getStyles('closeButton') }>
+              <CrossIcon onClick={ this.toggleMenu }
+                         styles={ this.props.styles }
+                         customIcon={ this.props.customCrossIcon }
+              />
+          </div>) : null;
 
-      // Add styles to user-defined menu items.
-      if (this.props.children) {
-        items = React.Children.map(this.props.children, (item, index) => {
-          const extraProps = {
-            key: index,
-            style: this.getStyles('item', index)
-          };
-          return React.cloneElement(item, extraProps);
-        });
-      }
+      const burgerButton = (!this.props.externalControl) ? (
+          <BurgerIcon onClick={ this.toggleMenu }
+                      styles={ this.props.styles }
+                      customIcon={ this.props.customBurgerIcon } />
+          ) : null;
 
       // Add a morph shape for animations that use SVG.
-      if (styles.svg) {
-        svg = (
+      const svg =  (styles.svg) ? (
           <div className="bm-morph-shape" style={ this.getStyles('morphShape') }>
             <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 100 800" preserveAspectRatio="none">
               <path d={ styles.svg.pathInitial }/>
             </svg>
           </div>
-        );
-      }
+        ) : null;
 
-      if (!this.props.noOverlay) {
-        overlay = <div className="bm-overlay" onClick={ this.toggleMenu } style={ this.getStyles('overlay') }></div>;
-      }
+      // Add styles to user-defined menu items.
+      const items = (this.props.children) ? React.Children.map(
+        this.props.children, (item, index) => {
+          const extraProps = {
+            key: index,
+            style: this.getStyles('item', index)
+          };
+          return React.cloneElement(item, extraProps);
+        }) : null;
+
+      const overlay =  (!this.props.noOverlay) ? (<div className="bm-overlay"
+        onClick={ this.toggleMenu }
+        style={ this.getStyles('overlay') }></div>) : null;
 
       return (
         <div>
@@ -232,11 +244,9 @@ export default (styles) => {
                 { items }
               </nav>
             </div>
-            <div style={ this.getStyles('closeButton') }>
-              <CrossIcon onClick={ this.toggleMenu } styles={ this.props.styles } customIcon={ this.props.customCrossIcon } />
-            </div>
+            { crossButton }
           </div>
-          <BurgerIcon onClick={ this.toggleMenu } styles={ this.props.styles } customIcon={ this.props.customBurgerIcon } />
+          { burgerButton }
         </div>
       );
     }

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -196,7 +196,6 @@ export default (styles) => {
     },
 
     render() {
-      debugger;
       const crossButton = (!this.props.noCrossButton) ? (
           <div style={ this.getStyles('closeButton') }>
               <CrossIcon onClick={ this.toggleMenu }


### PR DESCRIPTION
Make crossIcon optional, add external control boolean prop, added ternary operators instead if flow control.

If external control is active (redux e.g.) maybe the slider don't close or not open (this.state.isOpen and this.props.isOpen doesn't sync, due to external control).