### PR TITLE
Responsive squeeze effect with "push" fallback at given breakpoint 

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -156,6 +156,7 @@ const menus = {
   elastic: { buttonText: 'Elastic', items: 1 },
   bubble: { buttonText: 'Bubble', items: 1 },
   push: { buttonText: 'Push', items: 1 },
+  squeeze: { buttonText: 'Squeeze', items: 1 },
   pushRotate: { buttonText: 'Push Rotate', items: 2 },
   scaleDown: { buttonText: 'Scale Down', items: 2 },
   scaleRotate: { buttonText: 'Scale Rotate', items: 2 },

--- a/example/src/example.less
+++ b/example/src/example.less
@@ -29,6 +29,7 @@ a {
 
 main {
   height: 100%;
+  width: 100%;
   padding: 3em 2em;
   text-align: center;
   background: #b4bad2;
@@ -267,7 +268,8 @@ h1 {
 }
 
 #bubble,
-#push {
+#push,
+#squeeze {
   .menu-2;
 }
 

--- a/lib/BurgerIcon.js
+++ b/lib/BurgerIcon.js
@@ -58,7 +58,7 @@ var BurgerIcon = (0, _radium2['default'])(_react2['default'].createClass({
       padding: 0,
       border: 'none',
       fontSize: 12,
-      color: 'transparent',
+      textIndent: '-9999px',
       background: 'transparent',
       outline: 'none'
     };
@@ -85,7 +85,8 @@ var BurgerIcon = (0, _radium2['default'])(_react2['default'].createClass({
       icon,
       _react2['default'].createElement(
         'button',
-        { onClick: this.props.onClick,
+        { className: 'bm-burger-button__button',
+          onClick: this.props.onClick,
           onMouseEnter: this.handleHover,
           onMouseLeave: this.handleHover,
           style: buttonStyle },

--- a/lib/BurgerMenu.js
+++ b/lib/BurgerMenu.js
@@ -9,6 +9,7 @@ exports['default'] = {
   elastic: require('./menus/elastic'),
   bubble: require('./menus/bubble'),
   push: require('./menus/push'),
+  squeeze: require('./menus/squeeze'),
   pushRotate: require('./menus/pushRotate'),
   scaleDown: require('./menus/scaleDown'),
   scaleRotate: require('./menus/scaleRotate'),

--- a/lib/menuFactory.js
+++ b/lib/menuFactory.js
@@ -45,7 +45,8 @@ exports['default'] = function (styles) {
       pageWrapId: styles && styles.pageWrap ? _react2['default'].PropTypes.string.isRequired : _react2['default'].PropTypes.string,
       right: _react2['default'].PropTypes.bool,
       styles: _react2['default'].PropTypes.object,
-      width: _react2['default'].PropTypes.number
+      width: _react2['default'].PropTypes.number,
+      breakpoint: _react2['default'].PropTypes.number
     },
 
     toggleMenu: function toggleMenu() {
@@ -92,7 +93,7 @@ exports['default'] = function (styles) {
         return;
       }
 
-      var builtStyles = wrapperStyles(this.state.isOpen, this.props.width, this.props.right);
+      var builtStyles = wrapperStyles(this.state.isOpen, this.props.width, this.props.right, this.props.breakpoint);
 
       for (var prop in builtStyles) {
         if (builtStyles.hasOwnProperty(prop)) {
@@ -142,7 +143,8 @@ exports['default'] = function (styles) {
         outerContainerId: '',
         pageWrapId: '',
         styles: {},
-        width: 300
+        width: 300,
+        breakpoint: 960
       };
     },
 

--- a/lib/menus/squeeze.js
+++ b/lib/menus/squeeze.js
@@ -1,0 +1,40 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+		value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _menuFactory = require('../menuFactory');
+
+var _menuFactory2 = _interopRequireDefault(_menuFactory);
+
+var styles = {
+
+		pageWrap: function pageWrap(isOpen, width, right, breakpoint) {
+				if (window.innerWidth < breakpoint) {
+						return {
+								transform: isOpen ? '' : right ? 'translate3d(-' + width + 'px, 0, 0)' : 'translate3d(' + width + 'px, 0, 0)',
+								transition: 'transform 0.5s'
+						};
+				}
+				return {
+						width: isOpen ? '100%' : 'calc(100% - ' + width + 'px)',
+						position: 'absolute',
+						right: right ? 'initial' : '0',
+						left: right ? '0' : 'initial',
+						top: '0',
+						transition: 'width 0.5s'
+				};
+		},
+
+		outerContainer: function outerContainer(isOpen) {
+				return {
+						overflow: isOpen ? '' : 'hidden'
+				};
+		}
+};
+
+exports['default'] = (0, _menuFactory2['default'])(styles);
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-burger-menu",
-  "version": "1.9.1",
+  "version": "1.9.0",
   "description": "An off-canvas sidebar component with a collection of effects and styles using CSS transitions and SVG path animations",
   "main": "lib/BurgerMenu.js",
   "author": "Imogen Wentworth",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-burger-menu",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "An off-canvas sidebar component with a collection of effects and styles using CSS transitions and SVG path animations",
   "main": "lib/BurgerMenu.js",
   "author": "Imogen Wentworth",

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -47,7 +47,7 @@ const BurgerIcon = Radium(React.createClass({
       padding: 0,
       border: 'none',
       fontSize: 12,
-      color: 'transparent',
+	  textIndent: '-9999px',
       background: 'transparent',
       outline: 'none'
     };
@@ -71,7 +71,8 @@ const BurgerIcon = Radium(React.createClass({
     return (
       <div className="bm-burger-button" style={ [{ zIndex: 1 }, this.props.styles.bmBurgerButton] }>
         { icon }
-        <button onClick={ this.props.onClick }
+        <button className="bm-burger-button__button" 
+		  onClick={ this.props.onClick }
           onMouseEnter={ this.handleHover }
           onMouseLeave={ this.handleHover }
           style={ buttonStyle }>

--- a/src/BurgerMenu.js
+++ b/src/BurgerMenu.js
@@ -4,6 +4,7 @@ export default {
   elastic: require('./menus/elastic'),
   bubble: require('./menus/bubble'),
   push: require('./menus/push'),
+  squeeze: require('./menus/squeeze'),
   pushRotate: require('./menus/pushRotate'),
   scaleDown: require('./menus/scaleDown'),
   scaleRotate: require('./menus/scaleRotate'),

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -22,7 +22,8 @@ export default (styles) => {
       pageWrapId: styles && styles.pageWrap ? React.PropTypes.string.isRequired : React.PropTypes.string,
       right: React.PropTypes.bool,
       styles: React.PropTypes.object,
-      width: React.PropTypes.number
+      width: React.PropTypes.number,
+	  breakpoint: React.PropTypes.number
     },
 
     toggleMenu() {
@@ -69,7 +70,7 @@ export default (styles) => {
         return;
       }
 
-      const builtStyles = wrapperStyles(this.state.isOpen, this.props.width, this.props.right);
+      const builtStyles = wrapperStyles(this.state.isOpen, this.props.width, this.props.right, this.props.breakpoint);
 
       for (const prop in builtStyles) {
         if (builtStyles.hasOwnProperty(prop)) {
@@ -119,7 +120,8 @@ export default (styles) => {
         outerContainerId: '',
         pageWrapId: '',
         styles: {},
-        width: 300
+        width: 300,
+		breakpoint: 960
       };
     },
 

--- a/src/menus/squeeze.js
+++ b/src/menus/squeeze.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import menuFactory from '../menuFactory';
+
+const styles = {
+
+  pageWrap(isOpen, width, right, breakpoint) {
+	if(window.innerWidth < breakpoint) {
+		return {
+			transform: isOpen ? '' : right ? `translate3d(-${width}px, 0, 0)` : `translate3d(${width}px, 0, 0)`,
+			transition: 'transform 0.5s'
+		};
+	}
+    return {
+	  width: isOpen ? '100%' : `calc(100% - ${width}px)`,
+	  position: 'absolute',
+	  right: right ? 'initial' : '0',
+	  left: right ? '0' : 'initial',
+	  top: '0',
+      transition: 'width 0.5s'
+    };
+  },
+
+  outerContainer(isOpen) {
+    return {
+      overflow: isOpen ? '' : 'hidden'
+    };
+  }
+};
+
+export default menuFactory(styles);

--- a/test/BurgerIcon.spec.js
+++ b/test/BurgerIcon.spec.js
@@ -138,7 +138,7 @@ describe('BurgerIcon component', () => {
         padding: 0,
         border: 'none',
         fontSize: 12,
-        color: 'transparent',
+        textIndent: '-9999px',
         background: 'transparent',
         outline: 'none'
       };

--- a/test/squeeze.spec.js
+++ b/test/squeeze.spec.js
@@ -1,0 +1,70 @@
+'use strict';
+
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { expect } from 'chai';
+import createShallowComponent from './utils/createShallowComponent';
+import BurgerMenu from '../lib/BurgerMenu';
+const Menu = BurgerMenu.squeeze;
+
+describe('squeeze', () => {
+
+  let component, menuWrap, menu, itemList, firstItem;
+
+  function addWrapperElementsToDOM() {
+    let outerContainer = document.createElement('div');
+    outerContainer.setAttribute('id', 'outer-container');
+    let pageWrap = document.createElement('div');
+    pageWrap.setAttribute('id', 'page-wrap');
+    outerContainer.appendChild(pageWrap);
+    document.body.appendChild(outerContainer);
+  }
+
+  function removeWrapperElementsFromDOM() {
+    let outerContainer = document.getElementById('outer-container');
+    document.body.removeChild(outerContainer);
+  }
+
+  beforeEach(() => {
+    addWrapperElementsToDOM();
+  });
+
+  afterEach(() => {
+    removeWrapperElementsFromDOM();
+  });
+
+  it('has correct menuWrap styles', () => {
+    component = createShallowComponent(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' }><div>An item</div></Menu>);
+    menuWrap = component.props.children[1];
+    expect(menuWrap.props.style.position).to.equal('fixed');
+    expect(menuWrap.props.style.zIndex).to.equal(2);
+    expect(menuWrap.props.style.width).to.equal(300);
+    expect(menuWrap.props.style.height).to.equal('100%');
+  });
+
+  it('has correct menu styles', () => {
+    component = TestUtils.renderIntoDocument(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' }><div>An item</div></Menu>);
+    menu = TestUtils.findRenderedDOMComponentWithClass(component, 'bm-menu');
+    expect(menu.style.height).to.equal('100%');
+    expect(menu.style.boxSizing).to.equal('border-box');
+  });
+
+  it('has correct itemList styles', () => {
+    component = TestUtils.renderIntoDocument(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' }><div>An item</div></Menu>);
+    itemList = TestUtils.findRenderedDOMComponentWithClass(component, 'bm-item-list');
+    expect(itemList.style.height).to.equal('100%');
+  });
+
+  it('has correct item styles', () => {
+    component = TestUtils.renderIntoDocument(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' }><div>An item</div></Menu>);
+    firstItem = TestUtils.findRenderedDOMComponentWithClass(component, 'bm-item-list').children[0];
+    expect(firstItem.style.display).to.equal('block');
+    expect(firstItem.style.outline).to.equal('none');
+  });
+
+  it('can be positioned on the right', () => {
+    component = TestUtils.renderIntoDocument(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' } right><div>An item</div></Menu>);
+    menuWrap = TestUtils.findRenderedDOMComponentWithClass(component, 'bm-menu-wrap');
+    expect(menuWrap.style.right).to.equal('0px');
+  });
+});


### PR DESCRIPTION
Hello,

I've made some satisfying experiments with slightly modified "push" effect, which for lack of better name, I called "squeeze". It basically squeezes `#page-wrap` content instead of pushing it out of the viewport, making it more responsive. All remaining changes are listed here:

- Responsive squeeze effect added along with breakpoint prop to control the effect
- Burger button className and textIndent styling added #69 
- Squeeze.js test

Cheers