### PR TITLE
Restore position absolute for menu button

### DIFF
--- a/lib/BurgerIcon.js
+++ b/lib/BurgerIcon.js
@@ -49,7 +49,9 @@ var BurgerIcon = (0, _radium2['default'])(_react2['default'].createClass({
   render: function render() {
     var icon = undefined;
     var buttonStyle = {
-      position: 'relative',
+      position: 'absolute',
+      left: 0,
+      top: 0,
       width: '100%',
       height: '100%',
       margin: 0,

--- a/lib/CrossIcon.js
+++ b/lib/CrossIcon.js
@@ -46,7 +46,9 @@ var CrossIcon = (0, _radium2['default'])(_react2['default'].createClass({
       top: 8
     };
     var buttonStyle = {
-      position: 'relative',
+      position: 'absolute',
+      left: 0,
+      top: 0,
       width: '100%',
       height: '100%',
       margin: 0,

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -38,7 +38,9 @@ const BurgerIcon = Radium(React.createClass({
   render() {
     let icon;
     let buttonStyle = {
-      position: 'relative',
+      position: 'absolute',
+      left: 0,
+      top: 0,
       width: '100%',
       height: '100%',
       margin: 0,

--- a/src/CrossIcon.js
+++ b/src/CrossIcon.js
@@ -35,7 +35,9 @@ const CrossIcon = Radium(React.createClass({
       top: 8
     };
     var buttonStyle = {
-      position: 'relative',
+      position: 'absolute',
+      left: 0,
+      top: 0,
       width: '100%',
       height: '100%',
       margin: 0,

--- a/test/BurgerIcon.spec.js
+++ b/test/BurgerIcon.spec.js
@@ -129,7 +129,9 @@ describe('BurgerIcon component', () => {
       component = createShallowComponent(<BurgerIcon />);
       const button = component.props.children[1];
       const expected = {
-        position: 'relative',
+        position: 'absolute',
+        left: 0,
+        top: 0,
         width: '100%',
         height: '100%',
         margin: 0,

--- a/test/CrossIcon.spec.js
+++ b/test/CrossIcon.spec.js
@@ -113,7 +113,9 @@ describe('CrossIcon component', () => {
       component = createShallowComponent(<CrossIcon />);
       const button = component.props.children[1];
       const expected = {
-        position: 'relative',
+        position: 'absolute',
+        left: 0,
+        top: 0,
         width: '100%',
         height: '100%',
         margin: 0,


### PR DESCRIPTION
Hi,

https://github.com/negomi/react-burger-menu/commit/65117b16369e0d339a487ffbd9d89d4c70807099, published on v1.9.1, broke support for custom icons : As the button is now in position relative, it is positioned under the custom icon, and thus isn't simply clickable (the clickable space is positioned under the custom icon).

This PR restores a position absolute style for the button, and handles both the case with and without custom icons.