### PR TITLE
Updated Radium dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "browserify-optional": "^1.0.0",
     "classnames": "^2.1.1",
-    "radium": "^0.17.0",
+    "radium": "^0.18.0",
     "snapsvg": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Even though you declared Radium as ^0.17.0 in the dependencies npm was resolving v0.17.2 after Radium upgraded to v0.18.0. I can confirm that manually changing the dependency in package.json causes npm to resolve the correct version.