### PR TITLE
Change the way to hide button text

### DIFF
--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -46,7 +46,7 @@ const BurgerIcon = Radium(React.createClass({
       margin: 0,
       padding: 0,
       border: 'none',
-      textIndent: -9999,
+      opacity: 0,
       background: 'transparent',
       outline: 'none'
     };

--- a/test/BurgerIcon.spec.js
+++ b/test/BurgerIcon.spec.js
@@ -137,7 +137,7 @@ describe('BurgerIcon component', () => {
         margin: 0,
         padding: 0,
         border: 'none',
-        textIndent: -9999,
+        opacity: 0,
         background: 'transparent',
         outline: 'none'
       };


### PR DESCRIPTION
I was trying to get react-burger-menu to work with IE10, and faced a problem as my menu button wasn't clickable.

Tthe problem only occurs with a customIcon: for some reason I can't pinpoint, the button isn't clickable with its text at indent -9999px, (the image gets clicked instead).
I was however able to get it to work by removing the `textIndent: -9999` rule and forcing an `opacity: 0,`, which seems like it could be a good idea anyway as it doesn't force the creation of a 9999px wide element.

I tested the change with and without customIcon and didn't see any regression