### PR TITLE
exposing menuFactory for custom usage with example

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -88,15 +88,40 @@ let Demo = React.createClass({
     return items;
   },
 
+  getCustomMinMaxMenu(menuFactory) {
+    const styles = {
+      menuWrap(isOpen, width, right) {
+        width += 20;
+        let styles = {
+          width: 'inherit',
+          transform: isOpen ? '' : right ? 'translate3d(10%, 0, 0)' : 'translate3d(-10%, 0, 0)'
+        };
+        return styles;
+      }
+    };
+    return menuFactory(styles);
+  },
+
   getMenu() {
-    const Menu = BurgerMenu[this.state.currentMenu];
+    let Menu = BurgerMenu[this.state.currentMenu];
+    let customProps = {};
+    if (this.state.currentMenu === 'menuFactory') {
+      Menu = this.getCustomMinMaxMenu(Menu);
+      customProps = {
+        mouseEvents : true,
+        noOverlay: true,
+        customBurgerIcon: false,
+        customCrossIcon: false
+      };
+    }
+
     const items = this.getItems();
     let jsx;
 
     if (this.state.side === 'right') {
       jsx = (
         <MenuWrap wait={20} side={this.state.side}>
-          <Menu id={this.state.currentMenu} pageWrapId={'page-wrap'} outerContainerId={'outer-container'} right>
+          <Menu id={this.state.currentMenu} pageWrapId={'page-wrap'} outerContainerId={'outer-container'} {...customProps} right>
             {items}
           </Menu>
         </MenuWrap>
@@ -104,7 +129,7 @@ let Demo = React.createClass({
     } else {
       jsx = (
         <MenuWrap wait={20}>
-          <Menu id={this.state.currentMenu} pageWrapId={'page-wrap'} outerContainerId={'outer-container'}>
+          <Menu id={this.state.currentMenu} pageWrapId={'page-wrap'} outerContainerId={'outer-container'} {...customProps}>
             {items}
           </Menu>
         </MenuWrap>
@@ -159,7 +184,8 @@ const menus = {
   pushRotate: {buttonText: 'Push Rotate', items: 2},
   scaleDown: {buttonText: 'Scale Down', items: 2},
   scaleRotate: {buttonText: 'Scale Rotate', items: 2},
-  fallDown: {buttonText: 'Fall Down', items: 2}
+  fallDown: {buttonText: 'Fall Down', items: 2},
+  menuFactory: {buttonText: 'custom (min Max)', items: 1},
 };
 
 ReactDOM.render(<Demo menus={menus} />, document.getElementById('app'));

--- a/example/src/example.less
+++ b/example/src/example.less
@@ -281,3 +281,11 @@ h1 {
 #fallDown {
   .menu-4;
 }
+
+#menuFactory.bm-menu-state-close .bm-item-list a span{
+    display: none;
+}
+
+#menuFactory.bm-menu-state-open .bm-item-list a span{
+    display: inline;
+}

--- a/src/BurgerMenu.js
+++ b/src/BurgerMenu.js
@@ -7,5 +7,6 @@ export default {
   pushRotate: require('./menus/pushRotate'),
   scaleDown: require('./menus/scaleDown'),
   scaleRotate: require('./menus/scaleRotate'),
-  fallDown: require('./menus/fallDown')
+  fallDown: require('./menus/fallDown'),
+  menuFactory: require('./menuFactory')
 };

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -16,6 +16,7 @@ export default (styles) => {
       customCrossIcon: React.PropTypes.oneOfType([React.PropTypes.element, React.PropTypes.oneOf([false])]),
       id: React.PropTypes.string,
       isOpen: React.PropTypes.bool,
+      mouseEvents: React.PropTypes.bool,
       noOverlay: React.PropTypes.bool,
       onStateChange: React.PropTypes.func,
       outerContainerId: styles && styles.outerContainer ? React.PropTypes.string.isRequired : React.PropTypes.string,
@@ -128,6 +129,7 @@ export default (styles) => {
     getDefaultProps() {
       return {
         id: '',
+        mouseEvents: false,
         noOverlay: false,
         onStateChange: () => {},
         outerContainerId: '',
@@ -192,10 +194,19 @@ export default (styles) => {
     },
 
     render() {
+      let menuWrapProps = {};
+      if (this.props.mouseEvents) {
+        menuWrapProps = {
+          onMouseEnter: this.toggleMenu,
+          onMouseLeave: this.toggleMenu
+        };
+      };
+      let menuState = this.state.isOpen ? 'open' : 'close';
+      let menuWrapClassNames = `bm-menu-wrap bm-menu-state-${menuState}`;
       return (
         <div>
           {!this.props.noOverlay ? <div className="bm-overlay" onClick={this.toggleMenu} style={this.getStyles('overlay')} /> : null}
-          <div id={this.props.id} className="bm-menu-wrap" style={this.getStyles('menuWrap')}>
+          <div id={this.props.id} className={menuWrapClassNames} style={this.getStyles('menuWrap')} {...menuWrapProps}>
             {styles.svg ? (
               <div className="bm-morph-shape" style={this.getStyles('morphShape')}>
                 <svg width="100%" height="100%" viewBox="0 0 100 800" preserveAspectRatio="none">


### PR DESCRIPTION
Hi @negomi,
Thanks for this awesome react component. 

I have a slightly different requirement to have collapsed and expanded versions of menu. To do so exposing the `menuFactory` with `mouseEvent` prop.
Adding this PR for the same. Also added the example to visualize the usecase.
