### PR TITLE
Pin radium to 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "browserify-optional": "^1.0.0",
     "classnames": "^2.1.1",
     "eve": "~0.4.2",
-    "radium": "^0.18.1",
+    "radium": "0.18.1",
     "snapsvg-cjs": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #139 

Restore compatibility with `react` 0.14.x by removing dependency on `React.PureComponent` introduced in `radium` 0.18.2.