### PR TITLE
custom overlayClassName prop

### DIFF
--- a/lib/menuFactory.js
+++ b/lib/menuFactory.js
@@ -241,7 +241,7 @@ exports['default'] = function (styles) {
         return _react2['default'].createElement(
           'div',
           null,
-          !this.props.noOverlay ? _react2['default'].createElement('div', { className: 'bm-overlay', onClick: function () {
+          !this.props.noOverlay ? _react2['default'].createElement('div', { className: this.props.overlayClassName, onClick: function () {
               return _this3.toggleMenu();
             }, style: this.getStyles('overlay') }) : null,
           _react2['default'].createElement(
@@ -300,6 +300,7 @@ exports['default'] = function (styles) {
     noOverlay: _propTypes2['default'].bool,
     onStateChange: _propTypes2['default'].func,
     outerContainerId: styles && styles.outerContainer ? _propTypes2['default'].string.isRequired : _propTypes2['default'].string,
+    overlayClassName: _propTypes2['default'].string,
     pageWrapId: styles && styles.pageWrap ? _propTypes2['default'].string.isRequired : _propTypes2['default'].string,
     right: _propTypes2['default'].bool,
     styles: _propTypes2['default'].object,
@@ -311,6 +312,7 @@ exports['default'] = function (styles) {
     noOverlay: false,
     onStateChange: function onStateChange() {},
     outerContainerId: '',
+    overlayClassName: 'bm-overlay',
     pageWrapId: '',
     styles: {},
     width: 300

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -231,7 +231,7 @@ export default (styles) => {
     noOverlay: PropTypes.bool,
     onStateChange: PropTypes.func,
     outerContainerId: styles && styles.outerContainer ? PropTypes.string.isRequired : PropTypes.string,
-		overlayClassName: PropTypes.string,
+    overlayClassName: PropTypes.string,
     pageWrapId: styles && styles.pageWrap ? PropTypes.string.isRequired : PropTypes.string,
     right: PropTypes.bool,
     styles: PropTypes.object,
@@ -243,7 +243,7 @@ export default (styles) => {
     noOverlay: false,
     onStateChange: () => {},
     outerContainerId: '',
-		overlayClassName: 'bm-overlay',
+    overlayClassName: 'bm-overlay',
     pageWrapId: '',
     styles: {},
     width: 300

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -186,7 +186,7 @@ export default (styles) => {
     render() {
       return (
         <div>
-          {!this.props.noOverlay ? <div className="bm-overlay" onClick={() => this.toggleMenu()} style={this.getStyles('overlay')} /> : null}
+          {!this.props.noOverlay ? <div className={this.props.overlayClassName} onClick={() => this.toggleMenu()} style={this.getStyles('overlay')} /> : null}
           <div id={this.props.id} className={`bm-menu-wrap ${this.props.className || ''}`} style={this.getStyles('menuWrap')}>
             {styles.svg ? (
               <div className="bm-morph-shape" style={this.getStyles('morphShape')}>
@@ -231,6 +231,7 @@ export default (styles) => {
     noOverlay: PropTypes.bool,
     onStateChange: PropTypes.func,
     outerContainerId: styles && styles.outerContainer ? PropTypes.string.isRequired : PropTypes.string,
+		overlayClassName: PropTypes.string,
     pageWrapId: styles && styles.pageWrap ? PropTypes.string.isRequired : PropTypes.string,
     right: PropTypes.bool,
     styles: PropTypes.object,
@@ -242,6 +243,7 @@ export default (styles) => {
     noOverlay: false,
     onStateChange: () => {},
     outerContainerId: '',
+		overlayClassName: 'bm-overlay',
     pageWrapId: '',
     styles: {},
     width: 300

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -94,6 +94,12 @@ describe('menuFactory', () => {
       expect(overlay.props.className).to.contain('bm-overlay');
     });
 
+    it('accepts an optional overlayClassName', () => {
+      component = createShallowComponent(<Menu overlayClassName={ 'custom-class' } />);
+      const overlay = component.props.children[0];
+      expect(overlay.props.className).to.equal('custom-class');
+    });
+
     it('accepts an optional ID', () => {
       component = createShallowComponent(<Menu id={ 'menu-wrap' } />);
       const menuWrap = component.props.children[1];


### PR DESCRIPTION
Hi there, I saw [this comment](https://github.com/negomi/react-burger-menu/issues/124) and was inspired to add a quick PR to add a custom `overlayClassName` prop. Wanted to get your opinion.

The issue I'm seeing is that with CSS modules especially, it's hard to overwrite the current styles. In fact, while this does work to add and set the proper `className` string to the overlay, it seems like it isn't possible to overwrite the `background` (or, for that matter, any of [these styles](https://github.com/andrewmartin/react-burger-menu/blob/master/src/baseStyles.js#L20-L5)) if I'm not mistaken?

This does allow you to extend and add your own styles that aren't present in `src/baseStyles`, though, so it might be worthy of a merge.

Thanks for all your hard work on this, I'm really loving it!