### PR TITLE
add prop.bodyClassName

### DIFF
--- a/lib/menuFactory.js
+++ b/lib/menuFactory.js
@@ -130,6 +130,14 @@ exports['default'] = function (styles) {
         [html, body].forEach(function (element) {
           element.style['overflow-x'] = set ? 'hidden' : '';
         });
+
+        if (this.props.bodyClassName) {
+          if (set) {
+            body.classList.add(this.props.bodyClassName);
+          } else {
+            body.classList.remove(this.props.bodyClassName);
+          }
+        }
       }
 
       // Builds styles incrementally for a given element.
@@ -312,6 +320,7 @@ exports['default'] = function (styles) {
   })(_react.Component);
 
   Menu.propTypes = {
+    bodyClassName: _propTypes2['default'].oneOfType([_propTypes2['default'].string, _propTypes2['default'].arrayOf(_propTypes2['default'].string)]),
     burgerBarClassName: _propTypes2['default'].string,
     burgerButtonClassName: _propTypes2['default'].string,
     crossButtonClassName: _propTypes2['default'].string,
@@ -334,6 +343,7 @@ exports['default'] = function (styles) {
   };
 
   Menu.defaultProps = {
+    bodyClassName: '',
     burgerBarClassName: '',
     burgerButtonClassName: '',
     className: '',

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -83,6 +83,14 @@ export default (styles) => {
       [html, body].forEach((element) => {
         element.style['overflow-x'] = set ? 'hidden' : '';
       });
+
+      if (this.props.bodyClassName) {
+        if (set) {
+          body.classList.add(this.props.bodyClassName);
+        } else {
+          body.classList.remove(this.props.bodyClassName);
+        }
+      }
     }
 
     // Builds styles incrementally for a given element.
@@ -245,6 +253,7 @@ export default (styles) => {
   }
 
   Menu.propTypes = {
+    bodyClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.oneOfType(PropTypes.string)]),
     burgerBarClassName: PropTypes.string,
     burgerButtonClassName: PropTypes.string,
     crossButtonClassName: PropTypes.string,
@@ -267,6 +276,7 @@ export default (styles) => {
   };
 
   Menu.defaultProps = {
+    bodyClassName: '',
     burgerBarClassName: '',
     burgerButtonClassName: '',
     className: '',

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -272,6 +272,12 @@ describe('menuFactory', () => {
       const overlay = component.props.children[0];
       expect(overlay.props.className).to.contain('custom-class');
     });
+
+    it('accepts an optional bodyClassName', () => {
+      component = TestUtils.renderIntoDocument(<Menu bodyClassName={ 'custom-class' } />);
+      const body = TestUtils.findRenderedComponentWithType(component, 'body');
+      expect(body.classList.toString()).to.contain('custom-class');
+    });
   });
 
   describe('burger icon', () => {


### PR DESCRIPTION
Hi @negomi 
I'd like to add a class to `body` when the menu is open.

My intention is to prevent scrolling body. Although it's possible by adding `height: 100%` to `body` beforehand, this causes little issue on mobile Chrome. It will disable to toggle an address bar on scroll.
So I want to add `height: 100%` to `body` only when menu is open.

Hope this works for other users as well.