### PR TITLE
Reduce size of NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,9 @@
     "react",
     "react-component"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "lib",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This change removes all files from the package that are not needed to run it:

1. example
2. src
3. tasks
4. test
5. .editorconfig
6. .eslintignore
7. .eslintrc.json
8. .npmignore
9. .travis.yml
10. bower.json
11. gulpfile.js

Despite the files array containing just lib and dist, NPM will include LICENSE, README.md and package.json as well.