### PR TITLE
Add menu wrap class and property names to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ The component has the following helper classes:
 .bm-overlay {
   background: rgba(0, 0, 0, 0.3);
 }
+
+/* Styling of menu wrapper */
+.bm-menu-wrap {
+  width: 300px;
+}
 ```
 
 #### JavaScript
@@ -342,6 +347,9 @@ var styles = {
   },
   bmOverlay: {
     background: 'rgba(0, 0, 0, 0.3)'
+  },
+  bmMenuWrap: {
+    width: '300px'
   }
 }
 


### PR DESCRIPTION
While modifying react-burger-menu zIndexes to adhere a spec, I noticed these [weren't](https://github.com/negomi/react-burger-menu/blob/master/src/menuFactory.js#L199) missing, just undocumented.