### PR TITLE
fix(CrossIcon): Fixing "Close Menu" text visible on 4K monitor

### DIFF
--- a/src/CrossIcon.js
+++ b/src/CrossIcon.js
@@ -31,8 +31,9 @@ export default class CrossIcon extends Component {
       margin: 0,
       padding: 0,
       border: 'none',
-      textIndent: -9999,
+      textIndent: -99999,
       background: 'transparent',
+      color: 'transparent',
       outline: 'none',
       cursor: 'pointer'
     };

--- a/test/CrossIcon.spec.js
+++ b/test/CrossIcon.spec.js
@@ -132,8 +132,9 @@ describe('CrossIcon component', () => {
         margin: 0,
         padding: 0,
         border: 'none',
-        textIndent: -9999,
+        textIndent: -99999,
         background: 'transparent',
+        color: 'transparent',
         outline: 'none',
         cursor: 'pointer'
       };


### PR DESCRIPTION
When the screen size is bigger than ~2400px, a "Close Menu" text gets
visible on the page.

Closes #266