### PR TITLE
Add hover styling overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,11 @@ The component has the following helper classes:
   background: #373a47;
 }
 
+/* Color/shape of burger icon bars on hover*/
+.bm-burger-bars-hover {
+  background: #a90000;
+}
+
 /* Position and sizing of clickable cross button */
 .bm-cross-button {
   height: 24px;

--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ var styles = {
   bmBurgerBars: {
     background: '#373a47'
   },
+  bmBurgerBarsHover: {
+    background: #a90000;
+  },
   bmCrossButton: {
     height: '24px',
     width: '24px'

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -18,7 +18,8 @@ export default class BurgerIcon extends Component {
       left: 0,
       right: 0,
       top: 20 * (index * 2) + '%',
-      opacity: this.state.hover ? 0.6 : 1
+      opacity: this.state.hover ? 0.6 : 1,
+      ...(this.state.hover && this.props.styles.bmBurgerBarsHover)
     };
   }
 
@@ -53,7 +54,8 @@ export default class BurgerIcon extends Component {
           {[0, 1, 2].map(bar => (
             <span
               key={bar}
-              className={`bm-burger-bars ${this.props.barClassName}`.trim()}
+              className={`bm-burger-bars ${this.props.barClassName} ${this.state
+                .hover && 'bm-burger-bars-hover'}`.trim()}
               style={{
                 ...this.getLineStyle(bar),
                 ...this.props.styles.bmBurgerBars


### PR DESCRIPTION
Simple addition to add hover styling to the styles prop as well as an additional hover class.
Placed after default hover state so user can override existing styles or add to existing styles.

Without this you can add styling when hovering using this css selector:
```
.bm-burger-button:hover .bm-burger-bars{
  opacity: 0.3 !important;
}
```
However your forced to use !important when overriding existing styles.

This PR offers the ability to pass styling using the "styles" prop and another class selector to increase specificity.