### PR TITLE
Set overflow only if html/bodyClassName not set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-burger-menu",
-  "version": "2.5.4",
+  "version": "2.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8847,10 +8847,9 @@
       }
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
-      "dev": true
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -55,9 +55,14 @@ export default styles => {
 
     // Applies component-specific styles to external wrapper elements.
     applyWrapperStyles(set = true) {
+      const applyClass = (el, className) =>
+        el.classList[set ? 'add' : 'remove'](className);
+
+      if (this.props.htmlClassName) {
+        applyClass(document.querySelector('html'), this.props.htmlClassName);
+      }
       if (this.props.bodyClassName) {
-        const body = document.querySelector('body');
-        body.classList[set ? 'add' : 'remove'](this.props.bodyClassName);
+        applyClass(document.querySelector('body'), this.props.bodyClassName);
       }
 
       if (styles.pageWrap && this.props.pageWrapId) {
@@ -78,8 +83,6 @@ export default styles => {
     // Throws and returns if the required external elements don't exist,
     // which means any external page animations won't be applied.
     handleExternalWrapper(id, wrapperStyles, set) {
-      const html = document.querySelector('html');
-      const body = document.querySelector('body');
       const wrapper = document.getElementById(id);
 
       if (!wrapper) {
@@ -96,9 +99,18 @@ export default styles => {
       }
 
       // Prevent any horizontal scroll.
-      [html, body].forEach(element => {
-        element.style['overflow-x'] = set ? 'hidden' : '';
-      });
+      // Only set overflow-x as an inline style if htmlClassName or
+      // bodyClassName is not passed in. Otherwise, it is up to the caller to
+      // decide if they want to set the overflow style in CSS using the custom
+      // class names.
+      const applyOverflow = el =>
+        (el.style['overflow-x'] = set ? 'hidden' : '');
+      if (!this.props.htmlClassName) {
+        applyOverflow(document.querySelector('html'));
+      }
+      if (!this.props.bodyClassName) {
+        applyOverflow(document.querySelector('body'));
+      }
     }
 
     // Builds styles incrementally for a given element.
@@ -320,6 +332,7 @@ export default styles => {
     customOnKeyDown: PropTypes.func,
     disableCloseOnEsc: PropTypes.bool,
     disableOverlayClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    htmlClassName: PropTypes.string,
     id: PropTypes.string,
     isOpen: PropTypes.bool,
     itemClassName: PropTypes.string,
@@ -350,6 +363,7 @@ export default styles => {
     crossButtonClassName: '',
     crossClassName: '',
     disableCloseOnEsc: false,
+    htmlClassName: '',
     id: '',
     itemClassName: '',
     itemListClassName: '',

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -70,6 +70,12 @@ describe('menuFactory', () => {
     document.body.removeChild(outerContainer);
   }
 
+  function clearHtmlBodyInlineStyles() {
+    const html = document.querySelector('html');
+    const body = document.querySelector('body');
+    [html, body].forEach(el => el.removeAttribute('style'));
+  }
+
   it('exists and is not undefined', () => {
     assert.isDefined(menuFactory, 'menuFactory is defined');
   });
@@ -107,6 +113,15 @@ describe('menuFactory', () => {
       component = createShallowComponent(<Menu className={ 'custom-class' } />);
       const menuWrap = component.props.children[1];
       expect(menuWrap.props.className).to.contain('custom-class');
+    });
+
+    it('accepts an optional htmlClassName, applied only when menu is open', () => {
+      component = TestUtils.renderIntoDocument(<Menu htmlClassName={ 'custom-class' } />);
+      const html = document.querySelector('html');
+      expect(html.classList.contains('custom-class')).to.be.false;
+      component.toggleMenu();
+      expect(html.classList.contains('custom-class')).to.be.true;
+      component.toggleMenu();
     });
 
     it('accepts an optional bodyClassName, applied only when menu is open', () => {
@@ -434,6 +449,7 @@ describe('menuFactory', () => {
 
     afterEach(() => {
       removeWrapperElementsFromDOM();
+      clearHtmlBodyInlineStyles();
     });
 
     it('errors with the correct message if no wrapper element found', () => {
@@ -467,6 +483,15 @@ describe('menuFactory', () => {
       component.handleExternalWrapper('page-wrap', styles, true);
       expect(html.style['overflow-x']).to.equal('hidden');
       expect(body.style['overflow-x']).to.equal('hidden');
+    });
+
+    it('does not set styles on html and body elements if custom classes are used', () => {
+      const component = TestUtils.renderIntoDocument(<Menu pageWrapId={ 'page-wrap' } outerContainerId={ 'outer-container' } htmlClassName="custom-html" bodyClassName="custom-body" />);
+      let html = document.querySelector('html');
+      let body = document.querySelector('body');
+      component.handleExternalWrapper('page-wrap', styles, true);
+      expect(html.style['overflow-x']).to.equal('');
+      expect(body.style['overflow-x']).to.equal('');
     });
 
     it('clears styles from html and body elements', () => {


### PR DESCRIPTION
Fixes https://github.com/negomi/react-burger-menu/issues/268

Let me know if this is what you were thinking of in https://github.com/negomi/react-burger-menu/issues/268. I added a new prop named `htmlClassName` with the same behavior as `bodyClassName`, and I changed the logic so that it no longer sets `overflow-x` on the `html` or `body` elements if the respective custom class name prop is passed in.