### PR TITLE
Update lifecycle methods to fix StrictMode warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build": "gulp clean && NODE_ENV=production gulp build",
     "examples": "gulp dev:server",
     "lint": "eslint ./; true",
-    "prettier": "prettier \"src/**/*.js\" --single-quote --ignore-path ./.prettierignore --write && git add . && git status",
+    "prettier": "prettier \"src/**/*.js\" --single-quote --no-config --ignore-path ./.prettierignore --write && git add . && git status",
     "publish:site": "gulp publish:examples",
     "publish:version": "gulp commit:version && gulp push",
     "start": "gulp dev",

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -70,7 +70,10 @@ export default class BurgerIcon extends Component {
     return (
       <div
         className={`bm-burger-button ${this.props.className}`.trim()}
-        style={{ ...{ zIndex: 1000 }, ...this.props.styles.bmBurgerButton }}
+        style={{
+          ...{ zIndex: 1000 },
+          ...this.props.styles.bmBurgerButton
+        }}
       >
         {icon}
         <button

--- a/src/CrossIcon.js
+++ b/src/CrossIcon.js
@@ -65,7 +65,10 @@ export default class CrossIcon extends Component {
     return (
       <div
         className={`bm-cross-button ${this.props.className}`.trim()}
-        style={{ ...buttonWrapperStyle, ...this.props.styles.bmCrossButton }}
+        style={{
+          ...buttonWrapperStyle,
+          ...this.props.styles.bmCrossButton
+        }}
       >
         {icon}
         <button

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -14,6 +14,10 @@ export default styles => {
       this.state = {
         isOpen: false
       };
+
+      if (!styles) {
+        throw new Error('No styles supplied');
+      }
     }
 
     toggleMenu(options = {}) {
@@ -170,12 +174,6 @@ export default styles => {
       }
     }
 
-    componentWillMount() {
-      if (!styles) {
-        throw new Error('No styles supplied');
-      }
-    }
-
     componentDidMount() {
       // Bind ESC key handler (unless disabled or custom function supplied).
       if (this.props.customOnKeyDown) {
@@ -197,6 +195,15 @@ export default styles => {
     }
 
     componentDidUpdate() {
+      const wasToggled =
+        typeof this.props.isOpen !== 'undefined' &&
+        this.props.isOpen !== this.state.isOpen;
+      if (wasToggled) {
+        this.toggleMenu();
+        // Toggling changes SVG animation requirements, so we defer these until the next componentDidUpdate
+        return;
+      }
+
       if (styles.svg) {
         const morphShape = ReactDOM.findDOMNode(this, 'bm-morph-shape');
         const path = styles.svg.lib(morphShape).select('path');
@@ -210,15 +217,6 @@ export default styles => {
             path.attr('d', styles.svg.pathInitial);
           }, 300);
         }
-      }
-    }
-
-    componentWillReceiveProps(nextProps) {
-      if (
-        typeof nextProps.isOpen !== 'undefined' &&
-        nextProps.isOpen !== this.state.isOpen
-      ) {
-        this.toggleMenu();
       }
     }
 

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -6,6 +6,7 @@ import TestUtils from 'react-dom/test-utils';
 import { assert, expect } from 'chai';
 import sinon from 'sinon';
 import createShallowComponent from './utils/createShallowComponent';
+import createMountedComponent from './utils/createMountedComponent';
 import menuFactory from '../src/menuFactory';
 
 describe('menuFactory', () => {
@@ -180,6 +181,26 @@ describe('menuFactory', () => {
       const overlay = TestUtils.findRenderedDOMComponentWithClass(component, 'bm-overlay');
       TestUtils.Simulate.click(overlay);
       expect(component.state.isOpen).to.be.true;
+    });
+  });
+
+  describe('react <StrictMode>', () => {
+    let stubConsoleError;
+    let errorLogs = [];
+
+    beforeEach(() => {
+      errorLogs = [];
+      stubConsoleError = sinon.stub(console, 'error').callsFake((...args) => errorLogs.push(args));
+    });
+
+    afterEach(() => {
+      stubConsoleError.restore();
+    });
+
+    it('renders without strict mode warnings', () => {
+      Menu = menuFactory(mockStyles.basic);
+      component = createMountedComponent(<React.StrictMode><Menu /></React.StrictMode>);
+      expect(errorLogs).to.deep.equal([]);
     });
   });
 

--- a/test/utils/createMountedComponent.js
+++ b/test/utils/createMountedComponent.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+function createComponent(jsx) {
+  return TestRenderer.create(jsx);
+}
+
+export default createComponent;


### PR DESCRIPTION
Fixes #311.

* Moved error handling to the constructor (runs on mount)
* Moved `componentWillReceiveProps` logic to `componentDidUpdate`, as recommended in React docs
* Add `no-config` to `prettier` npm script to prevent dev config overriding project settings

The `componentWillReceiveProps` changes could possibly lead to duplicate renders, I haven't tested this in a real browser, however it is the recommended approach going forwards.