### PR TITLE
Check `disableCloseOnEsc` prop dynamically

### DIFF
--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -163,7 +163,12 @@ export default styles => {
     listenForClose(e) {
       e = e || window.event;
 
-      if (this.state.isOpen && (e.key === 'Escape' || e.keyCode === 27)) {
+      // Close on ESC, unless disabled
+      if (
+        !this.props.disableCloseOnEsc &&
+        this.state.isOpen &&
+        (e.key === 'Escape' || e.keyCode === 27)
+      ) {
         this.toggleMenu();
       }
     }
@@ -177,10 +182,10 @@ export default styles => {
     }
 
     componentDidMount() {
-      // Bind ESC key handler (unless disabled or custom function supplied).
+      // Bind ESC key handler (unless custom function supplied).
       if (this.props.customOnKeyDown) {
         window.onkeydown = this.props.customOnKeyDown;
-      } else if (!this.props.disableCloseOnEsc) {
+      } else {
         window.onkeydown = this.listenForClose.bind(this);
       }
 


### PR DESCRIPTION
Currently `disableCloseOnEsc` prop, which disables closing the menu on ESC is only checked once, on component mount, and the keyboard action is not updated if you reconsider later.

This PR implements a runtime check of the `disableCloseOnEsc` prop inside the default `onkeydown` handler (which is now installed regardless of the initial value of `disableCloseOnEsc`).

This is useful for example for implementing responsive "sicky" behavior, where on larger screens you want to dynamically open the menu, disable ESC key, overlay and mouse click-off, following a media query event.

See discussion in #39

See for example:
https://github.com/ivan-aksamentov/example-react-burger-menu-responsive
