### PR TITLE
Custom functions to handle your state when users triggers open or close actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can see a more detailed example of how to use `isOpen` [here](https://github
 If you keep the menu state yourself it might be convenient to pass a custom function to be used when the user triggers something that should open the menu.
 
 Called when:
-* The user clicks the burger icon
+* The user clicks on the burger icon
 
 ``` javascript
 <Menu onOpen={ handleOnOpen } />
@@ -193,7 +193,7 @@ Called when:
 If you keep the menu state yourself it might be convenient to pass a custom function to be used when the user triggers something that should close the menu.
 
 Called when:
-* The user clicks the cross icon
+* The user clicks on the cross icon
 * The user clicks on the overlay
 * The user hits the escape key
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ You can see a more detailed example of how to use `isOpen` [here](https://github
 
 *Note: If you want to render the menu open initially, you will need to set this property in your parent component's `componentDidMount()` function.*
 
+#### Open menu handler
+
+If you keep the menu state yourself it might be convenient to pass a custom function to be used when the user triggers something that should open the menu.
+
+Called when:
+* The user clicks the burger icon
+
+``` javascript
+<Menu onOpen={ handleOnOpen } />
+```
+
+#### Close menu handler
+
+If you keep the menu state yourself it might be convenient to pass a custom function to be used when the user triggers something that should close the menu.
+
+Called when:
+* The user clicks the cross icon
+* The user clicks on the overlay
+* The user hits the escape key
+
+``` javascript
+<Menu onClose={ handleOnOpen } />
+```
+
 #### State change
 
 You can detect whether the sidebar is open or closed by passing a callback function to `onStateChange`. The callback will receive an object containing the new state as its first argument.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Called when:
 * The user hits the escape key
 
 ``` javascript
-<Menu onClose={ handleOnOpen } />
+<Menu onClose={ handleOnClose } />
 ```
 
 #### State change

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-burger-menu",
-  "version": "2.6.14",
+  "version": "2.6.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -81,13 +81,15 @@ export default class BurgerIcon extends Component {
           onClick={this.props.onClick}
           onMouseOver={() => {
             this.setState({ hover: true });
-            if (this.props.onIconHoverChange)
+            if (this.props.onIconHoverChange) {
               this.props.onIconHoverChange({ isMouseIn: true });
+            }
           }}
           onMouseOut={() => {
             this.setState({ hover: false });
-            if (this.props.onIconHoverChange)
+            if (this.props.onIconHoverChange) {
               this.props.onIconHoverChange({ isMouseIn: false });
+            }
           }}
           style={buttonStyle}
         >

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -58,7 +58,7 @@ export default styles => {
         }, 500);
       });
     }
-    
+
     open() {
       if (typeof this.props.onOpen === 'function') {
         this.props.onOpen();
@@ -66,7 +66,7 @@ export default styles => {
         this.toggleMenu();
       }
     }
-    
+
     close() {
       if (typeof this.props.onClose === 'function') {
         this.props.onClose();
@@ -76,7 +76,11 @@ export default styles => {
     }
 
     overlayClick() {
-      if (this.props.disableOverlayClick === true || (typeof this.props.disableOverlayClick === 'function' && this.props.disableOverlayClick())) {
+      if (
+        this.props.disableOverlayClick === true ||
+        (typeof this.props.disableOverlayClick === 'function' &&
+          this.props.disableOverlayClick())
+      ) {
         return;
       } else {
         this.close();
@@ -199,7 +203,7 @@ export default styles => {
         this.state.isOpen &&
         (e.key === 'Escape' || e.keyCode === 27)
       ) {
-          this.close();
+        this.close();
       }
     }
 

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -58,6 +58,30 @@ export default styles => {
         }, 500);
       });
     }
+    
+    open() {
+      if (typeof this.props.onOpen === 'function') {
+        this.props.onOpen();
+      } else {
+        this.toggleMenu();
+      }
+    }
+    
+    close() {
+      if (typeof this.props.onClose === 'function') {
+        this.props.onClose();
+      } else {
+        this.toggleMenu();
+      }
+    }
+
+    overlayClick() {
+      if (this.props.disableOverlayClick === true || (typeof this.props.disableOverlayClick === 'function' && this.props.disableOverlayClick())) {
+        return;
+      } else {
+        this.close();
+      }
+    }
 
     // Applies component-specific styles to external wrapper elements.
     applyWrapperStyles(set = true) {
@@ -175,15 +199,7 @@ export default styles => {
         this.state.isOpen &&
         (e.key === 'Escape' || e.keyCode === 27)
       ) {
-        this.toggleMenu();
-      }
-    }
-
-    shouldDisableOverlayClick() {
-      if (typeof this.props.disableOverlayClick === 'function') {
-        return this.props.disableOverlayClick();
-      } else {
-        return this.props.disableOverlayClick;
+          this.close();
       }
     }
 
@@ -243,9 +259,7 @@ export default styles => {
           {!this.props.noOverlay && (
             <div
               className={`bm-overlay ${this.props.overlayClassName}`.trim()}
-              onClick={() =>
-                !this.shouldDisableOverlayClick() && this.toggleMenu()
-              }
+              onClick={() => this.overlayClick()}
               style={this.getStyles('overlay')}
             />
           )}
@@ -300,7 +314,7 @@ export default styles => {
             {this.props.customCrossIcon !== false && (
               <div style={this.getStyles('closeButton')}>
                 <CrossIcon
-                  onClick={() => this.toggleMenu()}
+                  onClick={() => this.close()}
                   styles={this.props.styles}
                   customIcon={this.props.customCrossIcon}
                   className={this.props.crossButtonClassName}
@@ -313,7 +327,7 @@ export default styles => {
           {this.props.customBurgerIcon !== false && (
             <div style={this.getStyles('burgerIcon')}>
               <BurgerIcon
-                onClick={() => this.toggleMenu()}
+                onClick={() => this.open()}
                 styles={this.props.styles}
                 customIcon={this.props.customBurgerIcon}
                 className={this.props.burgerButtonClassName}
@@ -355,7 +369,9 @@ export default styles => {
     morphShapeClassName: PropTypes.string,
     noOverlay: PropTypes.bool,
     noTransition: PropTypes.bool,
+    onClose: PropTypes.func,
     onIconHoverChange: PropTypes.func,
+    onOpen: PropTypes.func,
     onStateChange: PropTypes.func,
     outerContainerId:
       styles && styles.outerContainer


### PR DESCRIPTION
I made this pull request to solve this issue: https://github.com/negomi/react-burger-menu/issues/387

If you keep the state of the menu on your own it's handy to be able to pass in functions that is called when to users triggers actions to open or close the menu from within the menus own gui.