### PR TITLE
Feature/focus state for burger and cross buttons

### DIFF
--- a/example/src/example.less
+++ b/example/src/example.less
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Raleway:400,700,800);
+@import url(https://fonts.googleapis.com/css?family=Raleway:400, 700, 800);
 
 *, *:after, *:before { -webkit-box-sizing: border-box; box-sizing: border-box; }
 
@@ -130,6 +130,21 @@ h1 {
   top: 36px;
 }
 
+// Outline for burger button focus state
+.bm-burger-button button:focus {
+  outline: 2px solid #c94e50;
+  outline-offset: 8px;
+}
+
+// Background color for burger bars focus state
+.bm-burger-button {
+  button:focus + span {
+    span.bm-burger-bars {
+      background-color: #c94e50;
+    }
+  }
+}
+
 .right .bm-burger-button {
   left: initial;
   right: 36px;
@@ -181,6 +196,21 @@ h1 {
     padding: 2.5em 1.5em 0;
     font-size: 1.15em;
   }
+
+  // Outline for cross button focus state
+  .bm-cross-button button:focus {
+    outline: 2px solid #c94e50;
+    outline-offset: 2px;
+  }
+
+  // Background color for cross focus state
+  .bm-cross-button {
+    button:focus + span {
+      span.bm-cross {
+        background-color: #c94e50;
+      }
+    }
+  }
 }
 
 .menu-2 {
@@ -200,6 +230,20 @@ h1 {
     font-size: 1.7em;
     vertical-align: middle;
     color: #282a35;
+  }
+  // Outline for cross button focus state
+  .bm-cross-button button:focus {
+    outline: 2px solid #c94e50;
+    outline-offset: 2px;
+  }
+
+  // Background color for cross focus state
+  .bm-cross-button {
+    button:focus + span {
+      span.bm-cross {
+        background-color: #c94e50;
+      }
+    }
   }
 }
 
@@ -221,6 +265,20 @@ h1 {
     text-transform: uppercase;
     letter-spacing: 1px;
     font-size: 0.75em;
+  }
+  // Outline for cross button focus state
+  .bm-cross-button button:focus {
+    outline: 2px solid #c94e50;
+    outline-offset: 2px;
+  }
+
+  // Background color for cross focus state
+  .bm-cross-button {
+    button:focus + span {
+      span.bm-cross {
+        background-color: #c94e50;
+      }
+    }
   }
 }
 
@@ -261,6 +319,20 @@ h1 {
       background: rgba(0, 0, 0, 0.2);
       box-shadow: inset 0 -1px rgba(0, 0, 0, 0);
       color: #b8b7ad;
+    }
+  }
+  // Outline for cross button focus state
+  .bm-cross-button button:focus {
+    outline: 2px solid #c94e50;
+    outline-offset: 2px;
+  }
+
+  // Background color for cross focus state
+  .bm-cross-button {
+    button:focus + span {
+      span.bm-cross {
+        background-color: #c94e50;
+      }
     }
   }
 }

--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -76,7 +76,6 @@ export default class BurgerIcon extends Component {
           ...this.props.styles.bmBurgerButton
         }}
       >
-        {icon}
         <button
           onClick={this.props.onClick}
           onMouseOver={() => {
@@ -95,6 +94,7 @@ export default class BurgerIcon extends Component {
         >
           Open Menu
         </button>
+        {icon}
       </div>
     );
   }

--- a/src/CrossIcon.js
+++ b/src/CrossIcon.js
@@ -71,7 +71,6 @@ export default class CrossIcon extends Component {
           ...this.props.styles.bmCrossButton
         }}
       >
-        {icon}
         <button
           onClick={this.props.onClick}
           style={buttonStyle}
@@ -79,6 +78,7 @@ export default class CrossIcon extends Component {
         >
           Close Menu
         </button>
+        {icon}
       </div>
     );
   }

--- a/test/BurgerIcon.spec.js
+++ b/test/BurgerIcon.spec.js
@@ -7,7 +7,6 @@ import createShallowComponent from './utils/createShallowComponent';
 import BurgerIcon from '../src/BurgerIcon';
 
 describe('BurgerIcon component', () => {
-
   let component;
   const mockStylesProp = {
     bmBurgerButton: {
@@ -23,56 +22,65 @@ describe('BurgerIcon component', () => {
   });
 
   describe('when rendered successfully', () => {
-
     beforeEach(() => {
       component = createShallowComponent(<BurgerIcon />);
     });
 
     it('contains three span elements', () => {
-      expect(component.props.children[0].props.children).to.have.length(3);
+      expect(component.props.children[1].props.children).to.have.length(3);
     });
 
     it('contains a button element', () => {
-      expect(component.props.children[1].type).to.equal('button');
+      expect(component.props.children[0].type).to.equal('button');
     });
   });
 
   describe('wrapper element', () => {
-
     it('has the correct class', () => {
       component = createShallowComponent(<BurgerIcon />);
       expect(component.props.className).to.contain('bm-burger-button');
     });
 
     it('can be styled with props', () => {
-      component = createShallowComponent(<BurgerIcon styles={ mockStylesProp } />);
+      component = createShallowComponent(
+        <BurgerIcon styles={mockStylesProp} />
+      );
       expect(component.props.style.width).to.equal('40px');
     });
 
     it('accepts an optional className', () => {
-      component = createShallowComponent(<BurgerIcon className={ 'custom-class' } />);
+      component = createShallowComponent(
+        <BurgerIcon className={'custom-class'} />
+      );
       expect(component.props.className).to.contain('custom-class');
     });
   });
 
   describe('visual icon', () => {
-
     let icon;
 
     beforeEach(() => {
       component = createShallowComponent(<BurgerIcon />);
-      icon = component.props.children[0];
+      icon = component.props.children[1];
     });
 
     it('has the correct class', () => {
-      expect(icon.props.children[0].props.className).to.contain('bm-burger-bars');
-      expect(icon.props.children[1].props.className).to.contain('bm-burger-bars');
-      expect(icon.props.children[2].props.className).to.contain('bm-burger-bars');
+      expect(icon.props.children[0].props.className).to.contain(
+        'bm-burger-bars'
+      );
+      expect(icon.props.children[1].props.className).to.contain(
+        'bm-burger-bars'
+      );
+      expect(icon.props.children[2].props.className).to.contain(
+        'bm-burger-bars'
+      );
     });
 
     it('accepts an optional barClassName', () => {
-      component = createShallowComponent(<BurgerIcon barClassName={ 'custom-class' } />);
-      icon = component.props.children[0];
+      component = createShallowComponent(
+        <BurgerIcon barClassName={'custom-class'} />
+      );
+      icon = component.props.children[1];
       expect(icon.props.children[0].props.className).to.contain('custom-class');
     });
 
@@ -89,8 +97,10 @@ describe('BurgerIcon component', () => {
     });
 
     it('can be styled with props', () => {
-      component = createShallowComponent(<BurgerIcon styles={ mockStylesProp } />);
-      icon = component.props.children[0];
+      component = createShallowComponent(
+        <BurgerIcon styles={mockStylesProp} />
+      );
+      icon = component.props.children[1];
       expect(icon.props.children[0].props.style.background).to.equal('red');
       expect(icon.props.children[1].props.style.background).to.equal('red');
       expect(icon.props.children[2].props.style.background).to.equal('red');
@@ -98,25 +108,30 @@ describe('BurgerIcon component', () => {
 
     it('can be a custom element', () => {
       const element = <img src="icon.jpg" />;
-      component = createShallowComponent(<BurgerIcon customIcon={ element } />);
-      expect(component.props.children[0].type).to.equal('img');
-      expect(component.props.children[0].props.src).to.equal('icon.jpg');
+      component = createShallowComponent(<BurgerIcon customIcon={element} />);
+      expect(component.props.children[1].type).to.equal('img');
+      expect(component.props.children[1].props.src).to.equal('icon.jpg');
     });
   });
 
   describe('button', () => {
-
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(<BurgerIcon />);
     });
 
     it('contains descriptive text', () => {
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       expect(button.innerHTML).to.equal('Open Menu');
     });
 
     it('responds to hover events', () => {
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       TestUtils.SimulateNative.mouseOver(button);
       expect(component.state.hover).to.be.true;
       TestUtils.SimulateNative.mouseOut(button);
@@ -125,16 +140,23 @@ describe('BurgerIcon component', () => {
 
     it('behaves correctly when clicked', () => {
       let clickHandled = false;
-      function handleClick() { clickHandled = true; }
-      component = TestUtils.renderIntoDocument(<BurgerIcon onClick={ handleClick } />);
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      function handleClick() {
+        clickHandled = true;
+      }
+      component = TestUtils.renderIntoDocument(
+        <BurgerIcon onClick={handleClick} />
+      );
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       TestUtils.Simulate.click(button);
       expect(clickHandled).to.be.true;
     });
 
     it('has the correct styles', () => {
       component = createShallowComponent(<BurgerIcon />);
-      const button = component.props.children[1];
+      const button = component.props.children[0];
       const expected = {
         position: 'absolute',
         left: 0,
@@ -153,13 +175,20 @@ describe('BurgerIcon component', () => {
 
     it('exposes icon state from hover event handler', () => {
       let isMouseIn = false;
-      function handleIconHoverChange(hoverState){isMouseIn = hoverState.isMouseIn;}
-      component = TestUtils.renderIntoDocument(<BurgerIcon onIconHoverChange={handleIconHoverChange}/>);  
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      function handleIconHoverChange(hoverState) {
+        isMouseIn = hoverState.isMouseIn;
+      }
+      component = TestUtils.renderIntoDocument(
+        <BurgerIcon onIconHoverChange={handleIconHoverChange} />
+      );
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       TestUtils.SimulateNative.mouseOver(button);
       expect(isMouseIn).to.be.true;
       TestUtils.SimulateNative.mouseOut(button);
       expect(isMouseIn).to.be.false;
-    });    
+    });
   });
 });

--- a/test/CrossIcon.spec.js
+++ b/test/CrossIcon.spec.js
@@ -7,7 +7,6 @@ import createShallowComponent from './utils/createShallowComponent';
 import CrossIcon from '../src/CrossIcon';
 
 describe('CrossIcon component', () => {
-
   let component;
   const mockStylesProp = {
     bmCross: {
@@ -23,45 +22,44 @@ describe('CrossIcon component', () => {
   });
 
   describe('when rendered successfully', () => {
-
     beforeEach(() => {
       component = createShallowComponent(<CrossIcon />);
     });
 
     it('contains two span elements', () => {
-      expect(component.props.children[0].props.children).to.have.length(2);
+      expect(component.props.children[1].props.children).to.have.length(2);
     });
 
     it('contains a button element', () => {
-      expect(component.props.children[1].type).to.equal('button');
+      expect(component.props.children[0].type).to.equal('button');
     });
   });
 
   describe('wrapper element', () => {
-
     it('has the correct class', () => {
       component = createShallowComponent(<CrossIcon />);
       expect(component.props.className).to.contain('bm-cross-button');
     });
 
     it('can be styled with props', () => {
-      component = createShallowComponent(<CrossIcon styles={ mockStylesProp } />);
+      component = createShallowComponent(<CrossIcon styles={mockStylesProp} />);
       expect(component.props.style.height).to.equal('30px');
     });
 
     it('accepts an optional className', () => {
-      component = createShallowComponent(<CrossIcon className={ 'custom-class' } />);
+      component = createShallowComponent(
+        <CrossIcon className={'custom-class'} />
+      );
       expect(component.props.className).to.contain('custom-class');
     });
   });
 
   describe('visual icon', () => {
-
     let icon;
 
     beforeEach(() => {
       component = createShallowComponent(<CrossIcon />);
-      icon = component.props.children[0];
+      icon = component.props.children[1];
     });
 
     it('has the correct class', () => {
@@ -80,49 +78,60 @@ describe('CrossIcon component', () => {
     });
 
     it('can be styled with props', () => {
-      component = createShallowComponent(<CrossIcon styles={ mockStylesProp } />);
-      icon = component.props.children[0];
+      component = createShallowComponent(<CrossIcon styles={mockStylesProp} />);
+      icon = component.props.children[1];
       expect(icon.props.children[0].props.style.background).to.equal('red');
       expect(icon.props.children[1].props.style.background).to.equal('red');
     });
 
     it('can be a custom element', () => {
       const element = <img src="icon.jpg" />;
-      component = createShallowComponent(<CrossIcon customIcon={ element } />);
-      expect(component.props.children[0].type).to.equal('img');
-      expect(component.props.children[0].props.src).to.equal('icon.jpg');
+      component = createShallowComponent(<CrossIcon customIcon={element} />);
+      expect(component.props.children[1].type).to.equal('img');
+      expect(component.props.children[1].props.src).to.equal('icon.jpg');
     });
 
     it('accepts an optional crossClassName', () => {
-      component = createShallowComponent(<CrossIcon crossClassName={ 'custom-class' } />);
-      icon = component.props.children[0];
+      component = createShallowComponent(
+        <CrossIcon crossClassName={'custom-class'} />
+      );
+      icon = component.props.children[1];
       expect(icon.props.children[0].props.className).to.contain('custom-class');
     });
   });
 
   describe('button', () => {
-
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(<CrossIcon />);
     });
 
     it('contains descriptive text', () => {
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       expect(button.innerHTML).to.equal('Close Menu');
     });
 
     it('behaves correctly when clicked', () => {
       let clickHandled = false;
-      function handleClick() { clickHandled = true; }
-      component = TestUtils.renderIntoDocument(<CrossIcon onClick={ handleClick } />);
-      const button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      function handleClick() {
+        clickHandled = true;
+      }
+      component = TestUtils.renderIntoDocument(
+        <CrossIcon onClick={handleClick} />
+      );
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'button'
+      );
       TestUtils.Simulate.click(button);
       expect(clickHandled).to.be.true;
     });
 
     it('has the correct styles', () => {
       component = createShallowComponent(<CrossIcon />);
-      const button = component.props.children[1];
+      const button = component.props.children[0];
       const expected = {
         position: 'absolute',
         left: 0,


### PR DESCRIPTION
As accessibility is becoming more and more important, I thought it would be good to have clearer focus states for BurgerIcon and CrossIcons.

Before this PR it is/was possible to style the outline of both buttons to something more prominent, but usually visually distinctive focus states change the background color of the icons in addition to providing an outline.

As there is no "previous sibling" selector in CSS, and in both BurgerIcon and CrossIcon components the element order is 
```
{icon}
<button>
```
I had to change the order of these into

```
<button>
{icon}
```
so that it's possible to set styles to the sibling after of a button that is in a focus state.

Due to this order change I also had to modify the tests too, as many of them identified the element to be tested only by the order number of children.