### PR TITLE
Feature/keyboard interactions for menubutton and menu

### DIFF
--- a/src/BurgerIcon.js
+++ b/src/BurgerIcon.js
@@ -78,6 +78,7 @@ export default class BurgerIcon extends Component {
       >
         {icon}
         <button
+          id="react-burger-menu-btn"
           onClick={this.props.onClick}
           onMouseOver={() => {
             this.setState({ hover: true });

--- a/src/CrossIcon.js
+++ b/src/CrossIcon.js
@@ -73,6 +73,7 @@ export default class CrossIcon extends Component {
       >
         {icon}
         <button
+          id="react-burger-cross-btn"
           onClick={this.props.onClick}
           style={buttonStyle}
           tabIndex={this.props.tabIndex}

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -20,8 +20,79 @@ export default styles => {
       }
     }
 
+    focusOnFirstMenuItem() {
+      const firstItem = document.querySelector('.bm-item:first-child');
+      if (firstItem) {
+        firstItem.focus();
+      }
+    }
+
+    focusOnLastMenuItem() {
+      const lastItem = document.querySelector('.bm-item:last-child');
+      if (lastItem) {
+        lastItem.focus();
+      }
+    }
+
+    focusOnCrossButton() {
+      const crossButton = document.getElementById('react-burger-cross-btn');
+      if (crossButton) {
+        crossButton.focus();
+      }
+    }
+
+    focusOnMenuButton() {
+      const menuButton = document.getElementById('react-burger-menu-btn');
+      if (menuButton) {
+        menuButton.focus();
+      }
+    }
+
+    focusOnNextMenuItem() {
+      const currentMenuItem = document.querySelector('.bm-item:focus');
+      const lastItem = document.querySelector('.bm-item:last-child');
+      const isCrossButtonFocused = document.querySelector(
+        '#react-burger-cross-btn:focus'
+      );
+      if (currentMenuItem) {
+        const sibling = currentMenuItem.nextElementSibling;
+        if (sibling) {
+          sibling.focus();
+        } else if (currentMenuItem === lastItem) {
+          this.focusOnCrossButton();
+        }
+      } else if (isCrossButtonFocused) {
+        this.focusOnFirstMenuItem();
+      } else {
+        // If there's no current item, first item will come to focus
+        this.focusOnFirstMenuItem();
+      }
+    }
+
+    focusOnPreviousMenuItem() {
+      const currentMenuItem = document.querySelector('.bm-item:focus');
+      const firstMenuItem = document.querySelector('.bm-item:first-child');
+      const isCrossButtonFocused = document.querySelector(
+        '#react-burger-cross-btn:focus'
+      );
+      if (currentMenuItem) {
+        const sibling = currentMenuItem.previousElementSibling;
+        if (sibling) {
+          sibling.focus();
+        }
+        if (currentMenuItem === firstMenuItem) {
+          this.focusOnCrossButton();
+        }
+      } else if (isCrossButtonFocused) {
+        this.focusOnLastMenuItem();
+      } else {
+        // If there's no current item, first item will come to focus
+        this.focusOnFirstMenuItem();
+      }
+    }
+
     toggleMenu(options = {}) {
-      const { isOpen, noStateChange } = options;
+      const { isOpen, noStateChange, focusOnLastItem } = options;
       const newState = {
         isOpen: typeof isOpen !== 'undefined' ? isOpen : !this.state.isOpen
       };
@@ -33,12 +104,11 @@ export default styles => {
 
         if (!this.props.disableAutoFocus) {
           // For accessibility reasons, ensures that when we toggle open,
-          // we focus the first menu item if one exists.
+          // we focus the first or last menu item according to given parameter.
           if (newState.isOpen) {
-            const firstItem = document.querySelector('.bm-item');
-            if (firstItem) {
-              firstItem.focus();
-            }
+            focusOnLastItem
+              ? this.focusOnLastMenuItem()
+              : this.focusOnFirstMenuItem();
           } else {
             if (document.activeElement) {
               document.activeElement.blur();
@@ -194,16 +264,49 @@ export default styles => {
       return style(this.state.isOpen, formattedWidth, this.props.right, index);
     }
 
-    listenForClose(e) {
+    listenForKeyDowns(e) {
       e = e || window.event;
-
-      // Close on ESC, unless disabled
-      if (
-        !this.props.disableCloseOnEsc &&
-        this.state.isOpen &&
-        (e.key === 'Escape' || e.keyCode === 27)
-      ) {
-        this.close();
+      const menuButton = document.getElementById('react-burger-menu-btn');
+      // Key downs came from menu button
+      if (e.target === menuButton) {
+        // If down arrow, space or enter, open menu and focus on first menuitem
+        if (
+          !this.state.isOpen &&
+          (e.key === 'ArrowDown' || e.key === ' ' || e.key === 'Enter')
+        ) {
+          this.toggleMenu({ focusOnLastItem: false });
+        }
+        // If arrow up, open menu and focus on last menuitem
+        if (!this.state.isOpen && e.key === 'ArrowUp') {
+          this.toggleMenu({ focusOnLastItem: true });
+        }
+      }
+      // Key downs came from somewhere else, checking their values while menu is open
+      else {
+        // Close on ESC, unless disabled
+        if (
+          !this.props.disableCloseOnEsc &&
+          this.state.isOpen &&
+          (e.key === 'Escape' || e.keyCode === 27)
+        ) {
+          this.close();
+          this.focusOnMenuButton();
+        }
+        if (this.state.isOpen && e.key === 'ArrowDown') {
+          this.focusOnNextMenuItem();
+        }
+        if (this.state.isOpen && e.key === 'ArrowUp') {
+          this.focusOnPreviousMenuItem();
+        }
+        if (this.state.isOpen && e.key === 'Home') {
+          this.focusOnFirstMenuItem();
+        }
+        if (this.state.isOpen && e.key === 'End') {
+          this.focusOnLastMenuItem();
+        }
+        if (this.state.isOpen && e.key === 'Tab') {
+          this.close();
+        }
       }
     }
 
@@ -212,7 +315,7 @@ export default styles => {
       if (this.props.customOnKeyDown) {
         window.onkeydown = this.props.customOnKeyDown;
       } else {
-        window.onkeydown = this.listenForClose.bind(this);
+        window.onkeydown = this.listenForKeyDowns.bind(this);
       }
 
       // Allow initial open state to be set by props.
@@ -308,7 +411,7 @@ export default styles => {
                       key: index,
                       className: classList,
                       style: this.getStyles('item', index, item.props.style),
-                      tabIndex: this.state.isOpen ? 0 : -1
+                      tabIndex: -1
                     };
                     return React.cloneElement(item, extraProps);
                   }
@@ -323,7 +426,7 @@ export default styles => {
                   customIcon={this.props.customCrossIcon}
                   className={this.props.crossButtonClassName}
                   crossClassName={this.props.crossClassName}
-                  tabIndex={this.state.isOpen ? 0 : -1}
+                  tabIndex={-1}
                 />
               </div>
             )}

--- a/test/menuFactory.spec.js
+++ b/test/menuFactory.spec.js
@@ -95,7 +95,7 @@ describe('menuFactory', () => {
 
     it('sets global keydown event handler', () => {
       component = TestUtils.renderIntoDocument(<Menu />);
-      expect(window.onkeydown.name).to.contain('listenForClose');
+      expect(window.onkeydown.name).to.contain('listenForKeyDowns');
     });
 
     it('contains an overlay', () => {
@@ -524,19 +524,17 @@ describe('menuFactory', () => {
     });
   });
 
-  describe('listenForClose method', () => {
-
+  describe('listenForKeyDowns method', () => {
     it('closes the menu when Escape is pressed', () => {
       Menu = menuFactory(mockStyles.basic);
       component = TestUtils.renderIntoDocument(<Menu />);
       component.setState({ isOpen: true });
-      component.listenForClose({ key: 'Escape', target: '' });
+      component.listenForKeyDowns({ key: 'Escape', target: '' });
       expect(component.state.isOpen).to.be.false;
     });
   });
 
   describe('isOpen prop', () => {
-
     let container;
 
     beforeEach(() => {
@@ -589,21 +587,21 @@ describe('menuFactory', () => {
   });
 
   describe('customOnKeyDown prop', () => {
-
-    it('should be set for window.onkeydown instead of listenForClose', () => {
+    it('should be set for window.onkeydown instead of listenForKeyDowns', () => {
       Menu = menuFactory(mockStyles.basic);
       const customOnKeyDown = sinon.spy();
-      component = TestUtils.renderIntoDocument(<Menu customOnKeyDown={customOnKeyDown} />);
-      const listenForClose = sinon.spy(component, 'listenForClose');
+      component = TestUtils.renderIntoDocument(
+        <Menu customOnKeyDown={customOnKeyDown} />
+      );
+      const listenForKeyDowns = sinon.spy(component, 'listenForKeyDowns');
       component.setState({ isOpen: true });
       window.onkeydown();
       expect(customOnKeyDown.called).to.be.true;
-      expect(listenForClose.called).to.be.false;
+      expect(listenForKeyDowns.called).to.be.false;
     });
   });
 
   describe('open state', () => {
-
     let container;
 
     beforeEach(() => {


### PR DESCRIPTION
Modify the keyboard interaction for menu button and the menu according to [WAI ARIA practices 1.1 for navigation menu](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html) 

If menu button has focus, and
- down arrow, space or enter is pressed, menu opens and moves focus to first menu item
- up arrow is pressed, menu opens and moves focus to last menu item

While the menu is open, and

- enter is pressed: menu closes, menu button gets focus and the link inside menu item activates
- escape is pressed: menu closes, menu button gets focus
- up arrow is pressed: previous menu item focuses. (If focus is on the first menu item, cross button focuses. If cross button has focus, last menu item focuses.)
- down arrow is pressed: next menu item focuses. (If focus is on the last menu item, cross button focuses. If cross button has focus, first menu item focuses.)
- home is pressed: first menu item focuses
- end is pressed: last menu item focuses

What is not according to WAI ARIA practices
- tab is pressed (practices don't mention): menu closes and menu button focuses
- pressing keys from a to z doesn't focus on the menu item that starts with the letter in question. I'll create an issue about this.