### PR TITLE
Fix accessibility issue when menu is opened

### DIFF
--- a/src/components/CrossIcon.js
+++ b/src/components/CrossIcon.js
@@ -77,7 +77,7 @@ export default class CrossIcon extends Component {
           id="react-burger-cross-btn"
           onClick={this.props.onClick}
           style={buttonStyle}
-          tabIndex={this.props.isOpen ? 0 : -1}
+          {...(!this.props.isOpen && { tabIndex: -1})}
         >
           Close Menu
         </button>

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -392,7 +392,7 @@ export default styles => {
                     key: index,
                     className: classList,
                     style: getStyles('item', index, item.props.style),
-                    tabIndex: isOpen ? 0 : -1
+                    ...(!isOpen && { tabIndex: -1 })
                   };
                   return React.cloneElement(item, extraProps);
                 }


### PR DESCRIPTION
# Related Issue or PR:
https://github.com/negomi/react-burger-menu/issues/413
https://github.com/negomi/react-burger-menu/pull/426

# Issue:
When working with other libraries where menu is opened, keyboard navigation or focus is affected due to specificity of `tabindex` for `.bm-item` 


I can see why we need `tabIndex=-1` when something is closed. However, it may not be necessary to specify `tabIndex=0` when menu is opened. 

> omitted (or non-integer values)
The user agent will decide whether the element is [focusable](https://html.spec.whatwg.org/multipage/interaction.html#focusable), and if it is, whether it is [sequentially focusable](https://html.spec.whatwg.org/multipage/interaction.html#sequentially-focusable) or [click focusable](https://html.spec.whatwg.org/multipage/interaction.html#click-focusable) (or both).

According to https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex, or related [discussions](https://ux.stackexchange.com/questions/119952/when-is-it-wrong-to-put-tabindex-0-on-non-interactive-content), if an element is meant to be accessible, it should follow semantic html like using `button`, `heading` and if it's custom implementation, probably attribute `role` or `aria-*` should be used. Otherwise, we should let browser to do its own thing.
