### PR TITLE
fix: replaces use of `defaultProps` with default parameters

### DIFF
--- a/dist/react-burger-menu.js
+++ b/dist/react-burger-menu.js
@@ -1947,6 +1947,35 @@ exports['default'] = function (styles) {
         return ref.current;
     }
     var Menu = function Menu(props) {
+        var defaultProps = {
+                bodyClassName: '',
+                burgerBarClassName: '',
+                burgerButtonClassName: '',
+                className: '',
+                crossButtonClassName: '',
+                crossClassName: '',
+                disableAutoFocus: false,
+                disableCloseOnEsc: false,
+                htmlClassName: '',
+                id: '',
+                itemClassName: '',
+                itemListClassName: '',
+                menuClassName: '',
+                morphShapeClassName: '',
+                noOverlay: false,
+                noTransition: false,
+                onStateChange: function onStateChange() {
+                },
+                outerContainerId: '',
+                overlayClassName: '',
+                pageWrapId: '',
+                styles: {},
+                width: 300,
+                onIconHoverChange: function onIconHoverChange() {
+                },
+                itemListElement: 'nav'
+            };
+        props = _extends({}, defaultProps, props);
         var _React$useState = _react2['default'].useState(false);
         var _React$useState2 = _slicedToArray(_React$useState, 2);
         var isOpen = _React$useState2[0];
@@ -2043,8 +2072,9 @@ exports['default'] = function (styles) {
             }
         }
         function getStyle(style, index) {
-            var width = props.width;
-            var right = props.right;
+            var _props = props;
+            var width = _props.width;
+            var right = _props.right;
             var formattedWidth = typeof width !== 'string' ? width + 'px' : width;
             return style(isOpen, formattedWidth, right, index);
         }
@@ -2266,34 +2296,6 @@ exports['default'] = function (styles) {
             _propTypes2['default'].number,
             _propTypes2['default'].string
         ])
-    };
-    Menu.defaultProps = {
-        bodyClassName: '',
-        burgerBarClassName: '',
-        burgerButtonClassName: '',
-        className: '',
-        crossButtonClassName: '',
-        crossClassName: '',
-        disableAutoFocus: false,
-        disableCloseOnEsc: false,
-        htmlClassName: '',
-        id: '',
-        itemClassName: '',
-        itemListClassName: '',
-        menuClassName: '',
-        morphShapeClassName: '',
-        noOverlay: false,
-        noTransition: false,
-        onStateChange: function onStateChange() {
-        },
-        outerContainerId: '',
-        overlayClassName: '',
-        pageWrapId: '',
-        styles: {},
-        width: 300,
-        onIconHoverChange: function onIconHoverChange() {
-        },
-        itemListElement: 'nav'
     };
     return Menu;
 };

--- a/lib/menuFactory.js
+++ b/lib/menuFactory.js
@@ -57,6 +57,34 @@ exports['default'] = function (styles) {
   }
 
   var Menu = function Menu(props) {
+    var defaultProps = {
+      bodyClassName: '',
+      burgerBarClassName: '',
+      burgerButtonClassName: '',
+      className: '',
+      crossButtonClassName: '',
+      crossClassName: '',
+      disableAutoFocus: false,
+      disableCloseOnEsc: false,
+      htmlClassName: '',
+      id: '',
+      itemClassName: '',
+      itemListClassName: '',
+      menuClassName: '',
+      morphShapeClassName: '',
+      noOverlay: false,
+      noTransition: false,
+      onStateChange: function onStateChange() {},
+      outerContainerId: '',
+      overlayClassName: '',
+      pageWrapId: '',
+      styles: {},
+      width: 300,
+      onIconHoverChange: function onIconHoverChange() {},
+      itemListElement: 'nav'
+    };
+    props = _extends({}, defaultProps, props);
+
     var _React$useState = _react2['default'].useState(false);
 
     var _React$useState2 = _slicedToArray(_React$useState, 2);
@@ -180,8 +208,9 @@ exports['default'] = function (styles) {
     }
 
     function getStyle(style, index) {
-      var width = props.width;
-      var right = props.right;
+      var _props = props;
+      var width = _props.width;
+      var right = _props.right;
 
       var formattedWidth = typeof width !== 'string' ? width + 'px' : width;
       return style(isOpen, formattedWidth, right, index);
@@ -463,33 +492,6 @@ exports['default'] = function (styles) {
     right: _propTypes2['default'].bool,
     styles: _propTypes2['default'].object,
     width: _propTypes2['default'].oneOfType([_propTypes2['default'].number, _propTypes2['default'].string])
-  };
-
-  Menu.defaultProps = {
-    bodyClassName: '',
-    burgerBarClassName: '',
-    burgerButtonClassName: '',
-    className: '',
-    crossButtonClassName: '',
-    crossClassName: '',
-    disableAutoFocus: false,
-    disableCloseOnEsc: false,
-    htmlClassName: '',
-    id: '',
-    itemClassName: '',
-    itemListClassName: '',
-    menuClassName: '',
-    morphShapeClassName: '',
-    noOverlay: false,
-    noTransition: false,
-    onStateChange: function onStateChange() {},
-    outerContainerId: '',
-    overlayClassName: '',
-    pageWrapId: '',
-    styles: {},
-    width: 300,
-    onIconHoverChange: function onIconHoverChange() {},
-    itemListElement: 'nav'
   };
 
   return Menu;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-burger-menu",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9164,8 +9164,7 @@
         },
         "commander": {
           "version": "2.17.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -9978,8 +9977,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/src/menuFactory.js
+++ b/src/menuFactory.js
@@ -35,6 +35,33 @@ export default styles => {
   }
 
   const Menu = props => {
+    const defaultProps = {
+      bodyClassName: '',
+      burgerBarClassName: '',
+      burgerButtonClassName: '',
+      className: '',
+      crossButtonClassName: '',
+      crossClassName: '',
+      disableAutoFocus: false,
+      disableCloseOnEsc: false,
+      htmlClassName: '',
+      id: '',
+      itemClassName: '',
+      itemListClassName: '',
+      menuClassName: '',
+      morphShapeClassName: '',
+      noOverlay: false,
+      noTransition: false,
+      onStateChange: () => {},
+      outerContainerId: '',
+      overlayClassName: '',
+      pageWrapId: '',
+      styles: {},
+      width: 300,
+      onIconHoverChange: () => {},
+      itemListElement: 'nav'
+    };
+    props = { ...defaultProps, ...props };
     const [isOpen, setIsOpen] = React.useState(false);
     const timeoutId = React.useRef();
     const toggleOptions = React.useRef({});
@@ -461,33 +488,6 @@ export default styles => {
     right: PropTypes.bool,
     styles: PropTypes.object,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-  };
-
-  Menu.defaultProps = {
-    bodyClassName: '',
-    burgerBarClassName: '',
-    burgerButtonClassName: '',
-    className: '',
-    crossButtonClassName: '',
-    crossClassName: '',
-    disableAutoFocus: false,
-    disableCloseOnEsc: false,
-    htmlClassName: '',
-    id: '',
-    itemClassName: '',
-    itemListClassName: '',
-    menuClassName: '',
-    morphShapeClassName: '',
-    noOverlay: false,
-    noTransition: false,
-    onStateChange: () => {},
-    outerContainerId: '',
-    overlayClassName: '',
-    pageWrapId: '',
-    styles: {},
-    width: 300,
-    onIconHoverChange: () => {},
-    itemListElement: 'nav'
   };
 
   return Menu;


### PR DESCRIPTION
Resolves #507 by replacing use of `defaultProps` with default parameters resolving the following warning:

```
Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```